### PR TITLE
ci: 更新Netlify构建命令以包含依赖安装

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [build]
-  command = "pnpm build"
-  publish = "dist"
+command = "pnpm install && pnpm build"
+publish = "dist"
 
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
更新了Netlify的构建命令，在构建前先执行`pnpm install`以确保所有依赖都已安装。这样可以避免因依赖缺失导致的构建失败。